### PR TITLE
Enable GFM table support with Markdig

### DIFF
--- a/CodeCubeConsole/CodeCubeConsole.csproj
+++ b/CodeCubeConsole/CodeCubeConsole.csproj
@@ -42,8 +42,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="MarkdownSharp">
-      <HintPath>..\packages\MarkdownSharp.2.0.5\lib\net40\MarkdownSharp.dll</HintPath>
+    <Reference Include="Markdig">
+      <HintPath>..\packages\Markdig.0.30.0\lib\netstandard2.0\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="RazorEngine">
       <HintPath>..\packages\RazorEngine.3.10.0\lib\net45\RazorEngine.dll</HintPath>

--- a/CodeCubeConsole/Program.cs
+++ b/CodeCubeConsole/Program.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Markdig;
 
 namespace CodeCubeConsole
 {
@@ -146,10 +147,9 @@ namespace CodeCubeConsole
 		{
 			var allMarkdownFiles = Directory.EnumerateFiles ("content", "*.md", SearchOption.AllDirectories).ToArray();
 
-			MarkdownSharp.Markdown md = new MarkdownSharp.Markdown ();
+                        var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
-
-			foreach (var file in allMarkdownFiles) {
+                        foreach (var file in allMarkdownFiles) {
 				var content = File.ReadAllLines (file);
 				var meta = content.TakeWhile (line => line.Contains (":")).Select (line => {
 					var split = line.Split(':');
@@ -158,7 +158,7 @@ namespace CodeCubeConsole
 
 				var contentLines = content.Skip (meta.Count);
 				string markdownContent = string.Join (Environment.NewLine, contentLines);
-				string transformedContent = md.Transform (markdownContent);
+                                string transformedContent = Markdown.ToHtml (markdownContent, pipeline);
 
 				DateTime pubdate = DateTime.Parse (meta ["Date"]);
 				string url = Path.GetFileNameWithoutExtension (file);

--- a/CodeCubeConsole/packages.config
+++ b/CodeCubeConsole/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HtmlAgilityPack" version="1.11.48" targetFramework="net45" />
-  <package id="MarkdownSharp" version="2.0.5" targetFramework="net45" />
+  <package id="Markdig" version="0.30.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Razor" version="3.2.9" targetFramework="net45" />
   <package id="RazorEngine" version="3.10.0" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Static-Site-Generator
 
 
 CLI tool to generate a static site from a Wordpress export file, and markdown content.
- Uses RazorEngine as the templating engine, and a Wordpress post export file as the input.
+Uses RazorEngine as the templating engine, and a Wordpress post export file as the input.
+Markdown is parsed using the [Markdig](https://github.com/xoofx/markdig) library with advanced extensions enabled, so GitHub style tables and other syntax are supported out of the box.
 
 This was originally written primarily to support the move of my blog (http://codecube.net) off of Wordpress. However this tool could be generalized into a more broadly useful tool given time and attention :)
 


### PR DESCRIPTION
## Summary
- replace MarkdownSharp with Markdig
- enable advanced extensions so GitHub-style tables render correctly
- document Markdig in README

## Testing
- `nuget restore CodeCubeConsole.sln` *(fails: command not found)*
- `msbuild CodeCubeConsole.sln /p:Configuration=Release` *(fails: command not found)*
- `mono CodeCubeConsole/bin/Release/CodeCubeConsole.exe` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d543852b483238d8cd8db54acb0e8