### PR TITLE
Add resume page

### DIFF
--- a/CodeCubeConsole/Program.cs
+++ b/CodeCubeConsole/Program.cs
@@ -58,6 +58,11 @@ namespace CodeCubeConsole
             result = await Engine.CompileRenderStringAsync("about", abouttemplate, (object?)null);
             await SaveFile("About Joel Martinez", result, "/about/");
 
+            // the 'resume' page
+            string resumetemplate = await GetTemplate("resume");
+            result = await Engine.CompileRenderStringAsync("resume", resumetemplate, (object?)null);
+            await SaveFile("Joel Martinez - Resume", result, "/resume/");
+
             // syndication
             string rsstemplate = await GetTemplate("rss");
             result = await Engine.CompileRenderStringAsync("rss", rsstemplate, model.Take(15).ToArray());

--- a/CodeCubeConsole/Templates/master.cshtml
+++ b/CodeCubeConsole/Templates/master.cshtml
@@ -22,6 +22,7 @@
     <div>
 	  <a href="/" rel="home"><img height="50" width="50" src="//www.gravatar.com/avatar/a61a4be80ce39683142620a76299820b.png" title="ItsAMeee" /></a>
       <a href="/about/" rel="author">Joel Martinez</a>
+      <a href="/resume/">Resume</a>
 
       <img id="flair" src="/design/images/flair.png" />
     </div>

--- a/CodeCubeConsole/Templates/resume.cshtml
+++ b/CodeCubeConsole/Templates/resume.cshtml
@@ -1,0 +1,106 @@
+<div class="resume">
+<p>Principal Software Engineering Manager with 20+ years across developer tooling, AI, cloud, and mobile. Led 'Ask Learn' and Microsoft Q&A, built Xamarin docs tools and About.com apps, plus projects in finance and healthcare. Open source contributor and speaker.</p>
+
+<section>
+  <h2>Experience</h2>
+  <div class="two-columns">
+    <div class="column">
+      <h3>Microsoft</h3>
+      <p><strong>Principal Software Engineering Manager</strong><br>
+      Sep 2021 - Present, Orlando, FL (Remote)</p>
+      <ul>
+        <li>Joined Microsoft For Startups (Founder's Hub) in July 2024</li>
+        <li>Shipped "Ask Learn" for Microsoft Copilot for Azure (Ignite 2023)</li>
+        <li>Shipped AI Powered Q&A Assist (Build 2023, GA Oct 2023)</li>
+        <li>Led greenfield rewrite of Microsoft Q&A (Jan 2023, zero downtime)</li>
+      </ul>
+
+      <p><strong>Senior Software Engineer</strong><br>
+      Jul 2016 - Sep 2021, Orlando, FL</p>
+      <ul>
+        <li>Migrated managed API docs to docs.microsoft.com/dotnet/api</li>
+        <li>Tech lead in DevRel engineering; improved docs pipeline</li>
+        <li>Piloted Azure Search cognitive features with docs</li>
+      </ul>
+
+      <h3>Xamarin</h3>
+      <p><strong>Software Engineer</strong><br>
+      Aug 2013 - Jun 2016</p>
+      <ul>
+        <li>Built CMS for Xamarin’s developer portal with GitHub</li>
+        <li>Maintained Mono's documentation tools (monodoc, mdoc)</li>
+      </ul>
+
+      <h3>About.com</h3>
+      <p><strong>Lead Mobile Application Developer</strong><br>
+      Sep 2011 - Aug 2013</p>
+      <ul>
+        <li>Developed caloriecount.com mobile apps (Android, iOS)</li>
+        <li>Launched Calorie Camp to boost engagement</li>
+      </ul>
+
+      <h3>FlatRedBall LLC</h3>
+      <p><strong>Captain</strong><br>
+      Feb 2011 - Aug 2011</p>
+      <ul>
+        <li>Developed Xbox and Windows Phone games in C#</li>
+      </ul>
+
+      <h3>Credit Agricole CIB / SetClear</h3>
+      <p><strong>Senior Engineer / Development Manager</strong><br>
+      Aug 2010 - Aug 2011 / Mar 2007 - Aug 2010</p>
+      <ul>
+        <li>Led trade processing systems (ASP.NET MVC, BizTalk, MQ)</li>
+      </ul>
+    </div>
+    <div class="column">
+      <h3>Other Experience</h3>
+      <ul>
+        <li><strong>SiTEL (Contractor):</strong> Video integration in XNA training apps (2008)</li>
+        <li><strong>G-Trade:</strong> Client management tools (2006–2007)</li>
+        <li><strong>Wee Beastie (Contractor):</strong> Video rendering prototypes (2007)</li>
+        <li><strong>Community MX:</strong> Co-Founder, CMS and tech writing (2002–2006)</li>
+        <li><strong>Electronic Arts:</strong> Internal tools for Superman Returns game (2004–2006)</li>
+        <li><strong>Orlando .NET User Group:</strong> Founder & President (2001–2005)</li>
+        <li><strong>PayPal / ASPSoft:</strong> Consultant roles (2003–2004)</li>
+        <li><strong>Workable Solutions:</strong> Billing processor systems (2000–2003)</li>
+        <li><strong>Convergys:</strong> Tech Support (2000)</li>
+      </ul>
+
+      <h2>Skills</h2>
+      <ul>
+        <li><strong>Languages:</strong> C#, Python, JS/TS, VB.NET, SQL, ColdFusion</li>
+        <li><strong>Frameworks/Tools:</strong> .NET, ASP.NET MVC, WCF, Xamarin, XNA</li>
+        <li><strong>Platforms:</strong> Azure, GitHub, SharePoint, Windows Services</li>
+        <li><strong>Other:</strong> Team Management, Public Speaking, Agile</li>
+      </ul>
+
+      <h2>Publications</h2>
+      <ul>
+        <li>How we built “Ask Learn” – Microsoft Engineering Blog, 2023</li>
+        <li>Semantic Search – Microsoft Research Blog, 2021</li>
+        <li>Unified .NET Docs – Microsoft Dev Blog, 2018</li>
+      </ul>
+
+      <h2>Open Source</h2>
+      <ul>
+        <li>Scurvy.Media (XNA video library)</li>
+        <li>Mono Doc Tools (MDOC)</li>
+      </ul>
+
+      <h2>Volunteer</h2>
+      <ul>
+        <li>Orlando .NET UG President (2001–2005)</li>
+      </ul>
+
+      <h2>Interests</h2>
+      <ul>
+        <li>Game Development</li>
+        <li>Artificial Intelligence</li>
+        <li>Open Source</li>
+        <li>Mentoring Developers</li>
+      </ul>
+    </div>
+  </div>
+</section>
+</div>

--- a/CodeCubeConsole/out/design/style.css
+++ b/CodeCubeConsole/out/design/style.css
@@ -135,3 +135,47 @@ pre { font-family:Consolas, Courier New; font-size:.9em}
         padding-top:5px;
         color:#666;
 }
+
+/* Resume page layout */
+.resume {
+        font-family:"Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        line-height:1.6;
+        margin:0 auto;
+        padding:2rem;
+        max-width:1000px;
+        background-color:#fdfdfd;
+        color:#333;
+}
+.resume h1,
+.resume h2,
+.resume h3 {
+        color:#2c3e50;
+}
+.resume h1 {
+        border-bottom:2px solid #ccc;
+        padding-bottom:.3em;
+}
+.resume section {
+        margin-top:2em;
+}
+.resume .two-columns {
+        display:flex;
+        flex-wrap:wrap;
+        gap:2rem;
+}
+.resume .column {
+        flex:1;
+        min-width:300px;
+}
+.resume ul {
+        padding-left:1.2rem;
+}
+@media print {
+        .resume {
+                padding:0;
+                max-width:none;
+        }
+        .resume .two-columns {
+                display:block;
+        }
+}


### PR DESCRIPTION
## Summary
- add a resume page template
- generate `/resume` when building the site
- style resume layout
- add header link to the new resume page
- remove social table and redundant header from resume
- refine resume intro and volunteer section

## Testing
- `dotnet build CodeCubeConsole.sln` *(fails: NU1301 Unable to load the service index for source https://api.nuget.org/v3/index.json)*
- `dotnet run --project CodeCubeConsole` *(fails: NU1301 Unable to load the service index for source https://api.nuget.org/v3/index.json)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685e1de072dc83238fd89726a971ddee